### PR TITLE
fix: resolve metro config bugs in Expo and RN CLI setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,16 @@ const defaultResolver = config.resolver.resolveRequest;
 
 config = getBundleModeMetroConfig(config);
 
+const bundleModeResolver = config.resolver.resolveRequest;
+
 config.resolver.resolveRequest = (context, moduleName, platform) => {
   if (moduleName.startsWith('react-native-worklets/.worklets/')) {
-    return bundleModeMetroConfig.resolver.resolveRequest(
-      context,
-      moduleName,
-      platform
-    );
+    return bundleModeResolver(context, moduleName, platform);
   }
-  return defaultResolver(context, moduleName, platform);
+  if (defaultResolver) {
+    return defaultResolver(context, moduleName, platform);
+  }
+  return context.resolveRequest(context, moduleName, platform);
 };
 
 module.exports = config;
@@ -148,7 +149,10 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
       platform
     );
   }
-  return defaultResolver(context, moduleName, platform);
+  if (defaultResolver) {
+    return defaultResolver(context, moduleName, platform);
+  }
+  return context.resolveRequest(context, moduleName, platform);
 };
 
 module.exports = config;


### PR DESCRIPTION
Fixes broken metro config examples in the README — the Expo section used an undefined variable and both sections crashed when defaultResolver was not set. Verified with a fresh Expo 55 project.

Fixes: #5 