### PR TITLE
docs: update Worklets import forwarding setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ yarn add react-native-enriched-markdown react-native-worklets remend
 
 ### 1. `babel.config.js` — configure Worklets Babel plugin
 
-`react-native-streamdown` requires special options to be added to the Worklets Babel plugin config in `babel.config.js`, namely `bundleMode: true` and `workletizableModules: ['remend']`. Your final config could look like this:
+`react-native-streamdown` requires special options to be added to the Worklets Babel plugin config in `babel.config.js`, namely `bundleMode: true` and `importForwarding.moduleNames: ['remend']` when using `react-native-worklets` 0.10 or newer. Your final config could look like this:
 
 #### Expo
 
@@ -63,7 +63,9 @@ module.exports = function (api) {
         {
           bundleMode: true,
           // other options...
-          workletizableModules: ['remend'], // add this line
+          importForwarding: {
+            moduleNames: ['remend'], // add this line
+          },
         },
       ],
     ],
@@ -77,11 +79,15 @@ module.exports = function (api) {
 const workletsPluginOptions = {
   bundleMode: true,
   // other options...
-  workletizableModules: ['remend'], // add this line
+  importForwarding: {
+    moduleNames: ['remend'], // add this line
+  },
 };
 ```
 
-`workletizableModules: ['remend']` tells the Babel plugin to pre-bundle `remend` for the worklet runtime so it can be called off the JS thread.
+`importForwarding.moduleNames: ['remend']` tells the Babel plugin to forward the `remend` import into the generated worklet so it can be called off the JS thread.
+
+For older versions of `react-native-worklets`, use `workletizableModules: ['remend']` instead.
 
 ### 2. `metro.config.js` — configure Metro for monorepos
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ yarn add react-native-enriched-markdown react-native-worklets remend
 
 ### 1. `babel.config.js` — configure Worklets Babel plugin
 
-`react-native-streamdown` requires special options to be added to the Worklets Babel plugin config in `babel.config.js`, namely `bundleMode: true` and `importForwarding.moduleNames: ['remend']` when using `react-native-worklets` 0.10 or newer. Your final config could look like this:
+`react-native-streamdown` requires special options to be added to the Worklets Babel plugin config in `babel.config.js`, namely `bundleMode: true` and `importForwarding.moduleNames: ['remend']`. Your final config could look like this:
 
 #### Expo
 
@@ -87,7 +87,7 @@ const workletsPluginOptions = {
 
 `importForwarding.moduleNames: ['remend']` tells the Babel plugin to forward the `remend` import into the generated worklet so it can be called off the JS thread.
 
-For older versions of `react-native-worklets`, use `workletizableModules: ['remend']` instead.
+For `react-native-worklets` versions below 0.10, use `workletizableModules: ['remend']` instead.
 
 ### 2. `metro.config.js` — configure Metro for monorepos
 


### PR DESCRIPTION
## Summary

Updates the React Native Worklets setup instructions to use `importForwarding` for `remend` when using `react-native-worklets` 0.10 or newer.

With the old `workletizableModules` option on newer Worklets versions, `remend` can be captured into the generated worklet closure as a remote function, which can cause this runtime error when `StreamdownText` mounts:

```txt
[Worklets] Tried to synchronously call a Remote Function.
```

The updated config forwards the `remend` import into the generated worklet so markdown preprocessing can still run on the worklet runtime. The docs also keep a short note for older Worklets versions that still use `workletizableModules`.

Closes #21.

## Changes

- Replace `workletizableModules: ['remend']` with `importForwarding: { moduleNames: ['remend'] }` in the setup examples
- Update both Expo and React Native CLI snippets
- Keep a compatibility note for older `react-native-worklets` versions

## Test plan

- Docs-only change
- Verified the updated config in an Expo app using `react-native-worklets` 0.10.x
- Confirmed the generated worklet imports `remend` directly instead of capturing it in `__closure`
- Confirmed `StreamdownText` renders without the remote function error
