### PR TITLE
chore: update homepage url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "bugs": {
     "url": "https://github.com/software-mansion-labs/react-native-streamdown/issues"
   },
-  "homepage": "https://github.com/software-mansion-labs/react-native-streamdown#readme",
+  "homepage": "https://enriched.swmansion.com/streamdown",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },


### PR DESCRIPTION
Updates the package \`homepage\` field to point to the hosted documentation site instead of the GitHub README.

Analogous to software-mansion/react-native-enriched-markdown#553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)