### PR TITLE
fix: don't crash on web where worklet runtimes are unavailable

### DIFF
--- a/src/worklets/remendWorklet.ts
+++ b/src/worklets/remendWorklet.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import {
   createWorkletRuntime,
   scheduleOnRuntime,
@@ -19,7 +20,12 @@ const defaultRemendConfig: RemendOptions = {
   setextHeadings: true,
 };
 
-const remendRuntime = createWorkletRuntime({ name: 'remend-processor' });
+// react-native-worklets' web build ships the runtime APIs as throwing stubs,
+// so on web remend runs on the JS thread; scheduleOnRN works there (microtask).
+const remendRuntime =
+  Platform.OS === 'web'
+    ? null
+    : createWorkletRuntime({ name: 'remend-processor' });
 
 export function processRemendInWorklet(
   markdown: string,
@@ -29,6 +35,11 @@ export function processRemendInWorklet(
   const mergedConfig = config
     ? { ...defaultRemendConfig, ...config }
     : defaultRemendConfig;
+
+  if (remendRuntime == null) {
+    scheduleOnRN(onComplete, remend(markdown, mergedConfig));
+    return;
+  }
 
   scheduleOnRuntime(remendRuntime, () => {
     'worklet';


### PR DESCRIPTION
Fixes #27.

## Problem

`createWorkletRuntime` was called at module scope in `src/worklets/remendWorklet.ts`. `react-native-worklets`' web build implements the runtime APIs as deliberately throwing stubs, so any react-native-web bundle that imports `StreamdownText` crashed at module load.

## Fix

On web, skip the worklet runtime, run remend on the JS thread, and deliver the result through `scheduleOnRN` — its web implementation is a microtask, so both platforms use the same delivery primitive and `isStreaming` semantics stay identical. Native code path is unchanged.

Why a `Platform.OS` guard rather than a `remendWorklet.web.ts` fork: the guard is bundler-agnostic (a `.web.ts` fork relies on the consumer's resolver having the web extension configured — Metro does, bare webpack/Vite react-native-web setups may not) and avoids duplicating the config-merge logic across two files.

## Testing

We run this exact change as a patch in our production Expo app (iOS, Android and web from one JS bundle): iOS streaming behavior unchanged, and on web the chat streaming path renders progressively with remend repair (tables, bold, inline code mid-stream) instead of crashing at import.