### PR TITLE
chore(deps): bump react-native-enriched-markdown to 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,9 @@ yarn add react-native-enriched-markdown react-native-worklets remend
 
 | Package                          | Version |
 | -------------------------------- | ------- |
-| `react-native-enriched-markdown` | `>=0.4.0` |
+| `react-native-enriched-markdown` | `>=1.0.0` |
 | `react-native-worklets`          | `>=0.10.0` |
 | `remend`                         | `1.3.0` |
-
-> [!NOTE]
-> GFM table streaming requires `react-native-enriched-markdown >=0.6.0`.
 
 ---
 
@@ -152,7 +149,7 @@ import { StreamdownText } from 'react-native-streamdown';
 | -------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `remendConfig` | `RemendOptions` | Optional. Override the default remend processing config. See [remend docs](https://www.npmjs.com/package/remend) for all available options. |
 
-Pass `flavor="github"` to render GitHub Flavored Markdown. GFM table streaming requires `react-native-enriched-markdown >=0.6.0`.
+Pass `flavor="github"` to render GitHub Flavored Markdown.
 
 ---
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,7 +3,6 @@ PODS:
   - hermes-engine (250829098.0.10):
     - hermes-engine/Pre-built (= 250829098.0.10)
   - hermes-engine/Pre-built (250829098.0.10)
-  - iosMath (0.9.4)
   - RCTDeprecation (0.85.3)
   - RCTRequired (0.85.3)
   - RCTSwiftUI (0.85.3)
@@ -1857,9 +1856,8 @@ PODS:
     - React-utils (= 0.85.3)
     - ReactNativeDependencies
   - ReactNativeDependencies (0.85.3)
-  - ReactNativeEnrichedMarkdown (0.6.0):
+  - ReactNativeEnrichedMarkdown (1.0.2):
     - hermes-engine
-    - iosMath (~> 0.9)
     - RCTRequired
     - RCTTypeSafety
     - React-Core
@@ -2033,10 +2031,6 @@ DEPENDENCIES:
   - RNWorklets (from `../node_modules/react-native-worklets`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
-SPEC REPOS:
-  trunk:
-    - iosMath
-
 EXTERNAL SOURCES:
   FBLazyVector:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
@@ -2196,84 +2190,83 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: 266560b0f7be77966a13fc28143c4eef4713e619
-  iosMath: f7a6cbadf9d836d2149c2a84c435b1effc244cba
+  hermes-engine: a3ddfd8d1b1b725124c983df7ae9da23bf6f2a73
   RCTDeprecation: a4c521821fab57cbb125b36effe84d897d0dfa12
   RCTRequired: 9f3a7e5645d4bc3f551593de7550bb66ab6e42bc
   RCTSwiftUI: 239ed2eb9e73de5a6f518810630f0c95e01c8702
-  RCTSwiftUIWrapper: 966ca7f5f22ac0b2b2255fb09cffc381f5440b03
+  RCTSwiftUIWrapper: 7b8a1ffba8994a8f955c563511bffb74b4681317
   RCTTypeSafety: 2a6403ba3492c04510e7c15bd635461646c43bb2
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
-  React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: 9f34a2ef6eca8ac687891063b22cc6e8379a6066
-  React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
-  React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
+  React-Core: f90d375d3bab515ad00df30605ce1bf02e6db12f
+  React-Core-prebuilt: b736ca29cc2d800af557dd3cd529bcfbf331f20b
+  React-CoreModules: da4f80202ef954bdfb926ca4c9ac5f685900aa5c
+  React-cxxreact: 1d1d2a28a5f10e4e2e7cf2bfd54dc9c92c68c672
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189
-  React-defaultsnativemodule: cd64bc09d7ca24112bbaf1b91edbbcf3d81ea7dc
-  React-domnativemodule: dacf5bc055ae041039574f38b73a20b91e368774
-  React-Fabric: bb0baa33d91839631d315800eb23e9aaa4338a44
-  React-FabricComponents: c504d0b0e2f3054b2ba19af839f175cb361153c0
-  React-FabricImage: 91eaea1cc58d25ae2596a9277bcfe028f92374c3
-  React-featureflags: 5ac0455da0af12ca79b40402e2f42c5c7556b638
-  React-featureflagsnativemodule: df7da181b064f10f5959a7cd529b5aab3686ecb2
-  React-graphics: d25b1195baf24c7918543f4aff9be89cc080906f
-  React-hermes: 663286153a8ad6bf752b742654c766ff5e8991e7
-  React-idlecallbacksnativemodule: 0bd5392cb67f1ab25df736814b7c05213b1d3c68
-  React-ImageManager: a03eed3e3d4222130dc0ad503a1a5f3aa89de746
-  React-intersectionobservernativemodule: 5d0f1c3c7b30031b0f6f730ee52dd9d607e2c966
-  React-jserrorhandler: d5d6e7e20c5a2d6e8607e18d31d8712d7de676f6
-  React-jsi: eb7cc4cffcf24796cc302d5b2bca0e92544139a9
-  React-jsiexecutor: 65006f60e64c72c6b82f62ef6bd17c84846e73f8
-  React-jsinspector: 01e32e2247b2486117fbb143db7f7717ef462c6d
-  React-jsinspectorcdp: f1cbb34ca41d188ba22efd9b663cf258a911f6cd
-  React-jsinspectornetwork: f61acc94c881c41451f508abfe6efa748b956c21
-  React-jsinspectortracing: 9395894d9bd4d17931b9afcf230c0e7f4cb3d674
-  React-jsitooling: 03ead841daa12a93b18479f5e400ceab3732d36d
-  React-jsitracing: 4ae61c79e14360d1c6ab566031c62c490da78439
-  React-logger: bf149dea4343a9037b74bade36cced8b63f03f46
-  React-Mapbuffer: fec3e025f0ffba6b32cd2a1d7bbdee3e269aae90
-  React-microtasksnativemodule: ab33a818d339f5a1da308893c11b487be66121a8
-  React-mutationobservernativemodule: a42d1626651ccd7d0dc02a56e69d4ec77c248893
-  react-native-safe-area-context: 6b4966397ada0f7dd481e4486a2ef936834861a1
-  React-NativeModulesApple: deba264b03bd79c6bd61014fa30e40321b5e443a
-  React-networking: 35e6070b084f435429f85c5db40b4d5b38652fe9
+  React-defaultsnativemodule: 172d2ef7d11c531c40ee74f3be1ac98d258a817f
+  React-domnativemodule: 5a60a88075a35e20fa5879c94e7aa24e5f4071d0
+  React-Fabric: 5c1954e06c094623e46d51da2dc2c926621c03a5
+  React-FabricComponents: f32494150868073accd5d52d46b30a0496626813
+  React-FabricImage: dfcd2826b10f05c19e5bfa68d4937c4401c129db
+  React-featureflags: 84bcfcb8f91f9475e437f3dd579399085a4af51e
+  React-featureflagsnativemodule: 83111c4ee188b8859aaa8643c1be640442098fef
+  React-graphics: e0441bc695f5c682a3fb1b0fd317e10765700f12
+  React-hermes: da795ff5d5816d8940fca927c46dcdd81d7e9ad6
+  React-idlecallbacksnativemodule: b6d79e1c9e335564e17d18e2649fe7524c4e74e4
+  React-ImageManager: 0e137d7231092ddaa236f3520b67b4aa833e7079
+  React-intersectionobservernativemodule: 160b3c85bb5a3df2bf50e60619c0db50aadbef8c
+  React-jserrorhandler: 619d382632f5ed166541c03f7ba7deee76fb1b16
+  React-jsi: eac528e72d25146faa922ef1aad82d338addbb75
+  React-jsiexecutor: 2d3000fdde95d0da451f8976cdf9018448756023
+  React-jsinspector: 0377987f9635c64c5aaf72ec73aaf2b0b0da7744
+  React-jsinspectorcdp: 9db641a9cd0dd5b693df27d2e665ac2540ddc336
+  React-jsinspectornetwork: 61b00d0adfe6f175830660f1b98da576bc74eb0a
+  React-jsinspectortracing: 0f8d4f2ebd7523aece78cbc926cd4b6f2fc227dc
+  React-jsitooling: 36f3854063d507bc4d4a01227ebf1b63d9e24592
+  React-jsitracing: cddf044c0c2847d3f5822a984018fd5596c1d448
+  React-logger: 57001aefabd79d885589d2f31a8be05ccc393eaa
+  React-Mapbuffer: 1aa9126122d4247ffc24bf9d28d50ce923499a71
+  React-microtasksnativemodule: d86581169e9bb5bb6f5fc3c5052f890016c1bf21
+  React-mutationobservernativemodule: 9a0c4e866f1ef2a57acebc902ebacbdf469ae741
+  react-native-safe-area-context: a2325922b8594ddd27f98fb13437aec126be2502
+  React-NativeModulesApple: cc6ec4767844d610e92cc358bd3ea34937438d56
+  React-networking: a8ce15641ed7775d5b54a9d0d32defc367c2216e
   React-oscompat: 64a0c7ef5441855dc6e2a6afe8ba8f92aa05075e
-  React-perflogger: ca04287f205086a1edb5c95882be7b6068458889
-  React-performancecdpmetrics: cf1d0a3178ccd59353cedcacbda421f40100a889
-  React-performancetimeline: c9771212e7a43032d6f8d5edfb58280d46a7ce1f
+  React-perflogger: b2b0144e4ba8dd157c1e90f8ebb02d22edbd040d
+  React-performancecdpmetrics: 5a715ec33f2dea48a93a70db37a78b4f51f9fd5a
+  React-performancetimeline: c292077a6fbc7f423269b01aab0fb7cc48efe3c0
   React-RCTActionSheet: ab545c1e7b5f1ce4f8b40b6fa06afe2869095884
-  React-RCTAnimation: 343147a9cd68c93d0ca280799fedfc7102d76ce4
-  React-RCTAppDelegate: 5054754e92aaa9f8bfabe0f1022b84e46f3dcb57
-  React-RCTBlob: 8c7ae3422ca4e72bc64b7a0142fd730efc5d4dfb
-  React-RCTFabric: be458db054b206c4d8e4f20f666e75d5f2c2d420
-  React-RCTFBReactNativeSpec: 06db2e8d0f352d9fa23321aed1dd2cde25a3e83c
-  React-RCTImage: 481457bca63e039eb997f7d16c7560472f49657e
-  React-RCTLinking: 76cbb871240cec2dc5e7aa26c60f59e0ebbcf5a2
-  React-RCTNetwork: e23a778225b7672e38545d3c5c24e1f4aad6d15f
-  React-RCTRuntime: 93c830b3ab3f7b494bbe7ae7289784f8b07b3947
-  React-RCTSettings: 96196b535bef147381f96cc60ce9bda85d8be848
-  React-RCTText: 749ebbd1a999fd84d80f37002ea3bf597fcea6df
-  React-RCTVibration: 5b41a7f274757c2928845981d970916ef9e4ca14
+  React-RCTAnimation: 1f9a58c7b74c25ea4ca6e6fbd05f37cc4919097a
+  React-RCTAppDelegate: 856f82c57b47c1795009af585cfb7b87fe2d3b5a
+  React-RCTBlob: 1cb18861a19be0b4d7e44bed9315e791413399f9
+  React-RCTFabric: 081853d9efb9b38fa868c1ff3d60e48106fe2a24
+  React-RCTFBReactNativeSpec: cbc760c7a889bfce20746ca0037b97c10ea58665
+  React-RCTImage: 0d94b22644ca87fcb778a8fa3ffbf990bc9028df
+  React-RCTLinking: 881a0c6772dd05a14ab0edfea05dadb698ec8090
+  React-RCTNetwork: feb412861e3fff3426eb0961c2acdd96bee8dce1
+  React-RCTRuntime: c61b848ffadc0209fe643406370d58021bd3585d
+  React-RCTSettings: b6e14b8764f807ebe9be2e7f0d72be83b359ac26
+  React-RCTText: 1ecd4f85ff609183ebec858cf94c0f27a9dec163
+  React-RCTVibration: 3611aa5cb59094632b3141d72c50cbb8ce3d5b08
   React-rendererconsistency: 6708acd4bc39c1c5b00164370d0010d93b324c1f
-  React-renderercss: 80eb778756fed511d6128fc005188ac9008b0baf
-  React-rendererdebug: b46f338fb9d3f0bea6cf0621016c6c5a7a18e72e
-  React-RuntimeApple: c494b2089fad4a0c553cf63c2bb265f7eca2285d
-  React-RuntimeCore: b0bb151c3e2b26c6309d45d05c54aa65a6e0c094
-  React-runtimeexecutor: 00b18635b6216a1708f6eb35dbadfd993ec91c7b
-  React-RuntimeHermes: bb44c4c574ce1b9507cad2e6be015344d18b94a9
-  React-runtimescheduler: e1631e57209cb94b3efc29002b6a049cac3f6599
-  React-timing: 356b88317ca60d373b0d94b6e7a71b0a572899f5
-  React-utils: ccc01da318979af773259c4f6cdb1876f6f86f1a
-  React-webperformancenativemodule: f8b97c2cb6cfa94e92a503c09ad6d491c50a1390
-  ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
-  ReactCodegen: c8f81e6c6f762dcf442a6203a1fb58f7dafc8014
-  ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: eabebfb058c393bfb7df5806c1a99602a213f6da
-  ReactNativeEnrichedMarkdown: 861d6937d7f4a6481e8446538dc715c93b545143
-  RNWorklets: 53439575fed8525fb8d1cabcc05a3d4d91e6ffe4
+  React-renderercss: d4a70898381431dcc07d6deba94a7eaef0cc9058
+  React-rendererdebug: ad92235a960983f69183e2e59e2bce21e72c80a0
+  React-RuntimeApple: 53a5b8fe60b044ec6fd4d254d66b7da69314a295
+  React-RuntimeCore: 97e125471c0b8313db2bbeb1e9dc001a5503e979
+  React-runtimeexecutor: 0ff42dcf1cc4bc7a89d29532a16a7d2d3849fb2f
+  React-RuntimeHermes: da5a1b7e39f3db1a7b3303d75d4c5bb6cd7c0d49
+  React-runtimescheduler: 0e24c80f0c8b6e822a33e4ad89e0ab555704eedb
+  React-timing: f23e82ad46673716e34a786048414ab80f237594
+  React-utils: 2851415c698da4b18331f9a445825d260fffa32c
+  React-webperformancenativemodule: 9f29ed34f6f6c01dac688b95fd2dfcbccf3aed7a
+  ReactAppDependencyProvider: a54c0c9b976766e1b6d5e2bb4d1ad0d15913e9e1
+  ReactCodegen: 9af5798e943781fd2318dab7b60f25337388047c
+  ReactCommon: 3ec2a55999d296af90c24beb66c8a77dc660d3ef
+  ReactNativeDependencies: 317a5f1f80b730a374f017eb06c0b2cd23571673
+  ReactNativeEnrichedMarkdown: 6935bbd33cbe891b77d6e6ec5e86f2fef1cf7332
+  RNWorklets: 82a5f27dcf3bb69267ec6ce662a756a4d3f61522
   Yoga: 77dfa8673de2874e1855002ae59c68b8be9b007b
 
 PODFILE CHECKSUM: 9e4e62c5cde7380decd7f99194592e6482943d20
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "19.2.3",
     "react-native": "0.85.3",
-    "react-native-enriched-markdown": "0.6.0",
+    "react-native-enriched-markdown": "1.0.2",
     "react-native-safe-area-context": "^5.7.0",
     "react-native-streamdown": "*",
     "react-native-worklets": "0.10.2",

--- a/example/src/StreamingMarkdownSimulator.tsx
+++ b/example/src/StreamingMarkdownSimulator.tsx
@@ -112,6 +112,8 @@ export default function StreamingMarkdownSimulator() {
       >
         <StreamdownText
           markdown={partialMarkdown}
+          flavor="github"
+          remendConfig={{ katex: true }}
           onLinkPress={(e) => handleLinkPress(e.url)}
         />
         {isStreaming && <Text style={styles.streamingDot}>● Streaming…</Text>}

--- a/example/src/sampleMarkdown.ts
+++ b/example/src/sampleMarkdown.ts
@@ -16,7 +16,7 @@ There are **three main types** of black holes:
 2. **Supermassive black holes** — found at the center of most galaxies
 3. **Intermediate black holes** — a class between stellar and supermassive
 
-| Type         | Typical mass (in M☉) | Where they form                 |
+| Type         | Typical mass         | Where they form                 |
 | ------------ | -------------------- | ------------------------------- |
 | Stellar      | 3 – 100              | Collapse of a massive star      |
 | Intermediate | 100 – 100,000        | Star cluster mergers (proposed) |

--- a/example/src/sampleMarkdown.ts
+++ b/example/src/sampleMarkdown.ts
@@ -16,6 +16,12 @@ There are **three main types** of black holes:
 2. **Supermassive black holes** — found at the center of most galaxies
 3. **Intermediate black holes** — a class between stellar and supermassive
 
+| Type         | Typical mass (in M☉) | Where they form                 |
+| ------------ | -------------------- | ------------------------------- |
+| Stellar      | 3 – 100              | Collapse of a massive star      |
+| Intermediate | 100 – 100,000        | Star cluster mergers (proposed) |
+| Supermassive | 10⁶ – 10¹⁰           | Galactic centers                |
+
 ### Stellar Black Holes
 
 When a massive star (_typically > 25 solar masses_) exhausts its nuclear fuel, it may collapse under its own gravity to form a stellar black hole.
@@ -24,11 +30,47 @@ When a massive star (_typically > 25 solar masses_) exhausts its nuclear fuel, i
 
 These have masses ranging from **millions** to **billions** of solar masses. The supermassive black hole at the center of the Milky Way is called \`Sagittarius A*\`.
 
+## The Math Behind the Horizon
+
+The size of the event horizon is set by the **Schwarzschild radius** $r_s = \\frac{2GM}{c^2}$, where $G$ is the gravitational constant, $M$ is the mass, and $c$ is the speed of light.
+
+For a non-rotating black hole this defines a perfect sphere:
+
+$$
+r_s = \\frac{2GM}{c^2}
+$$
+
+Black holes also radiate. The **Hawking temperature** falls off with mass:
+
+$$
+T_H = \\frac{\\hbar c^3}{8 \\pi G M k_B}
+$$
+
+## Estimating a Radius
+
+A quick way to compute the Schwarzschild radius of the Sun in Python:
+
+\`\`\`python
+G = 6.674e-11   # gravitational constant
+c = 2.998e8     # speed of light
+M = 1.989e30    # one solar mass, in kg
+
+r_s = 2 * G * M / c ** 2
+print(f"{r_s:.0f} m")  # ~2950 m
+\`\`\`
+
 ## Key Properties
 
 - **Mass**: Determines the size of the event horizon
 - **Spin**: Black holes can rotate at nearly the speed of light
 - **Charge**: Theoretically possible but astrophysically negligible
+
+## Open Questions
+
+- [x] Detect black hole mergers via gravitational waves
+- [x] Image a supermassive black hole's shadow
+- [ ] Directly observe Hawking radiation
+- [ ] Reconcile ~~classical singularities~~ with quantum gravity
 
 ## Famous Image
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react": "19.2.3",
     "react-native": "^0.85.3",
     "react-native-builder-bob": "^0.40.18",
-    "react-native-enriched-markdown": "0.6.0",
+    "react-native-enriched-markdown": "1.0.2",
     "react-native-sse": "1.2.1",
     "react-native-worklets": "0.10.2",
     "react-test-renderer": "19.2.3",
@@ -95,7 +95,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-enriched-markdown": ">=0.4.0",
+    "react-native-enriched-markdown": ">=1.0.0",
     "react-native-worklets": ">=0.10.0",
     "remend": "1.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10503,20 +10503,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-enriched-markdown@npm:0.6.0":
-  version: 0.6.0
-  resolution: "react-native-enriched-markdown@npm:0.6.0"
+"react-native-enriched-markdown@npm:1.0.2":
+  version: 1.0.2
+  resolution: "react-native-enriched-markdown@npm:1.0.2"
   peerDependencies:
-    "@expo/config-plugins": ">=50.0.0"
     katex: ">=0.16.0"
     react: "*"
     react-native: "*"
   peerDependenciesMeta:
-    "@expo/config-plugins":
-      optional: true
     katex:
       optional: true
-  checksum: 10c0/9d71d6c44bd317b3d575ac4a4d1501ee55f280da090a7660813b3d86d23f67fcce4e2f016fd9cc2ef0c567f47807d4a065af60dfd3278c05e5f81423480f521c
+  checksum: 10c0/018b2efd6502ecd68b3b2caa994d8da137ada77c25c6a12803fa58021ac1ca2afcb3096a9d092fa8d89afa0d9ee56cae66472a19149f14ee7f545083a45057f6
   languageName: node
   linkType: hard
 
@@ -10564,7 +10561,7 @@ __metadata:
     react: "npm:19.2.3"
     react-native: "npm:0.85.3"
     react-native-builder-bob: "npm:^0.40.18"
-    react-native-enriched-markdown: "npm:0.6.0"
+    react-native-enriched-markdown: "npm:1.0.2"
     react-native-monorepo-config: "npm:^0.3.3"
     react-native-safe-area-context: "npm:^5.7.0"
     react-native-streamdown: "npm:*"
@@ -10601,7 +10598,7 @@ __metadata:
     react: "npm:19.2.3"
     react-native: "npm:^0.85.3"
     react-native-builder-bob: "npm:^0.40.18"
-    react-native-enriched-markdown: "npm:0.6.0"
+    react-native-enriched-markdown: "npm:1.0.2"
     react-native-sse: "npm:1.2.1"
     react-native-worklets: "npm:0.10.2"
     react-test-renderer: "npm:19.2.3"
@@ -10612,7 +10609,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-enriched-markdown: ">=0.4.0"
+    react-native-enriched-markdown: ">=1.0.0"
     react-native-worklets: ">=0.10.0"
     remend: 1.3.0
   languageName: unknown


### PR DESCRIPTION
## Summary

Bumps `react-native-enriched-markdown` from `0.6.0` to the newly-released stable **`1.0.2`**, and enriches the example so the demo actually exercises the 1.0 feature set.

## Dependency changes

- `package.json` — devDependency `0.6.0` → `1.0.2`
- `package.json` — peerDependency floor `>=0.4.0` → **`>=1.0.0`** (require the stable line)
- `example/package.json` — `0.6.0` → `1.0.2`
- `README.md` — version table updated; removed the now-obsolete "GFM table streaming requires >=0.6.0" notes (the floor is 1.0.0, so they no longer apply)
- `yarn.lock` — regenerated

## Example changes

- `example/src/sampleMarkdown.ts` — the streaming sample now includes a **GFM table**, **inline + display LaTeX** (Schwarzschild radius, Hawking temperature), a **fenced code block**, a **task list**, and **strikethrough**, so the simulator demonstrates the full rendering surface.
- `example/src/StreamingMarkdownSimulator.tsx` — renders with `flavor="github"` (tables / task lists / code blocks / strikethrough) and `remendConfig={{ katex: true }}` (streaming completion of incomplete LaTeX).

## Compatibility

`StreamdownText` uses `EnrichedMarkdownText` + `EnrichedMarkdownTextProps` and the `markdown` / `streamingAnimation` / `selectable` / `flavor` props — all still exported and compatible in 1.0.2. `yarn typecheck` is clean against the new version.

## Verification

- `yarn install` resolves `react-native-enriched-markdown@1.0.2`
- `yarn typecheck` clean · `yarn lint` clean · `yarn test` — 3 suites / 6 passed + 1 todo · `yarn prepare` (bob build) succeeds

> [!NOTE]
> The peer floor moving to `>=1.0.0` is a breaking change for consumers still on the 0.x line — worth calling out in the release notes.