### PR TITLE
test: make remendWorklet test a module to fix typecheck

### DIFF
--- a/src/__tests__/remendWorklet.test.ts
+++ b/src/__tests__/remendWorklet.test.ts
@@ -1,3 +1,8 @@
+// This file uses only jest globals with no imports; `export {}` marks it a
+// module so its top-level consts are module-scoped (tsconfig has
+// verbatimModuleSyntax), not leaked into the global script scope.
+export {};
+
 // Stable, mutable Platform the mock factory closes over. jest.isolateModules
 // re-requires react-native on every load, so a plain outer mutation wouldn't
 // reach the module — this shared object does.


### PR DESCRIPTION
## What

`src/__tests__/remendWorklet.test.ts` had no top-level `import`/`export`, so under tsconfig's `verbatimModuleSyntax` its top-level `const`s (`mockPlatform`, `mockRemend`, `worklets`) were treated as **global script** declarations and `tsc` reported `TS2451` redeclarations. This broke `yarn typecheck` (exit 2) and the CI **typecheck** job. Added `export {}` to mark the file a module so its top-level bindings are module-scoped.

Introduced by #31 (`b03746e`); present on `main`. The published artifact is unaffected (tests are excluded from the bob build), but CI on `main` is red without this.

## Why now

Blocks a clean `0.3.0` release — the publish workflow ships from `main`, and `main` should be green first.

## Verification

- `yarn lint` ✅
- `yarn typecheck` ✅ (was exit 2, now 0)
- `yarn test` ✅ 6 passed, 1 todo
- `yarn prepare` (build) ✅
- Fresh RN 0.85.3 consumer project: installed the packed tarball + peer deps, iOS & Android Metro bundles compile with the full worklet pipeline ✅

Created with usage of AI tools