### PR TITLE
chore: prepare 0.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ config.watchFolders.push(
 module.exports = getBundleModeMetroConfig(config);
 ```
 
+### 3. Patch Metro for synchronous worklet indexing (recommended)
+
+Bundle Mode isolates worklets into separate modules **on the fly**. Metro builds its file map when it starts, so it can fail to index these freshly generated modules in time — you'll see `Failed to get the SHA-1 for .../.worklets/<id>.js` and need to reload the app a few times before the bundle succeeds.
+
+To avoid this, patch Metro to allow synchronous indexing of the new modules, as described in the [Worklets Bundle Mode setup guide](https://docs.swmansion.com/react-native-worklets/docs/bundleMode/setup). This repository's `example/` app applies such a patch via `resolutions` — use it as a reference.
+
+> Without the patch the app still works, but expect a few extra reloads on first launch while Metro catches up. The one-shot `react-native bundle` command (offline release bundling) requires the patch.
+
 ---
 
 ## Usage

--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,7 @@
     "react-native-safe-area-context": "^5.7.0",
     "react-native-streamdown": "*",
     "react-native-worklets": "0.10.2",
-    "remend": "1.2.2"
+    "remend": "1.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-streamdown",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Markdown Streaming ",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10566,7 +10566,7 @@ __metadata:
     react-native-safe-area-context: "npm:^5.7.0"
     react-native-streamdown: "npm:*"
     react-native-worklets: "npm:0.10.2"
-    remend: "npm:1.2.2"
+    remend: "npm:1.3.0"
   languageName: unknown
   linkType: soft
 
@@ -10850,13 +10850,6 @@ __metadata:
   bin:
     release-it: bin/release-it.js
   checksum: 10c0/54888f271b665a4efc57b635664438ab256193d24a10928e19997c38b854056ad1bb2d653ede85c7552d45ecdcb1f1aa8861b8c0c27f9aaaf00ba916d3ae1781
-  languageName: node
-  linkType: hard
-
-"remend@npm:1.2.2":
-  version: 1.2.2
-  resolution: "remend@npm:1.2.2"
-  checksum: 10c0/e5ff2a4d908114942507765b787e497853a3f58a81adb07f49502bb5e1b9ce492b977fe8cc5b00eb633cd9858b507ee0d0331bd3d667a30e3228ff2ef08332ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- bump version to 0.3.0
- document the recommended Metro patch for Bundle Mode worklet indexing
- align example remend to 1.3.0 to match the shipped peerDependency